### PR TITLE
update frontend-maven-plugin to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.3</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
I'm on a macbook air with M1 chip and executing `mvn clean spring-boot:run` failed with the following error

```
[INFO] Installing node version v14.15.3
[INFO] Downloading https://nodejs.org/dist/v14.15.3/node-v14.15.3-darwin-arm64.tar.gz to xxx
[INFO] No proxies configured
[INFO] No proxy was configured, downloading directly
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.078 s
[INFO] Finished at: 2021-04-12T11:30:19+03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm (install node and npm) on project testing-spring-boot-applications-masterclass: Could not download Node.js: Got error code 404 from the server. -> [Help 1]
```

after updating the maven plugin, the build passes this step.