### PR TITLE
add jna as test dependency for testcontainers on M1 with arm-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.8.0</version>
+      <scope>test</scope>
+      <!-- https://github.com/testcontainers/testcontainers-java/issues/3834#issuecomment-788995236 -->
+    </dependency>
+    <dependency>
       <groupId>com.codeborne</groupId>
       <artifactId>selenide</artifactId>
       <version>${selenide.version}</version>


### PR DESCRIPTION
Expected `mvn -Dtest=de.rieckpil.courses.book.review.ReviewRepositoryNoInMemoryTest test` to result in a green built, but got 
```
09:49:43.245 [main] INFO  o.t.d.DockerMachineClientProviderStrategy - docker-machine executable was not found on PATH ([/opt/homebrew/bin, /usr/local/sbin, /Users/lars/Library/Android/sdk/tools, /Users/lars/Library/Android/sdk/platform-tools, /Users/lars/bin, /usr/local/bin, /usr/bin, /bin, /usr/sbin, /sbin, /usr/local/MacGPG2/bin, /usr/local/share/dotnet, ~/.dotnet/tools, /Library/Apple/usr/bin, /Library/Java/JavaVirtualMachines/zulu-16.jdk/Contents/Home/bin])
09:49:43.247 [main] ERROR o.t.d.DockerClientProviderStrategy - Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
09:49:43.247 [main] ERROR o.t.d.DockerClientProviderStrategy -     UnixSocketClientProviderStrategy: failed with exception RuntimeException (java.lang.UnsatisfiedLinkError: /Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp: dlopen(/Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp, 1): no suitable image found.  Did find:
        /Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp: no matching architecture in universal wrapper
        /Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp: no matching architecture in universal wrapper). Root cause UnsatisfiedLinkError (/Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp: dlopen(/Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp, 1): no suitable image found.  Did find:
        /Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp: no matching architecture in universal wrapper
        /Users/lars/Library/Caches/JNA/temp/jna16384185352047345994.tmp: no matching architecture in universal wrapper)
09:49:43.247 [main] ERROR o.t.d.DockerClientProviderStrategy -     UnixSocketClientProviderStrategy: failed with exception RuntimeException (java.lang.NoClassDefFoundError: Could not initialize class org.testcontainers.shaded.com.github.dockerjava.okhttp.UnixSocketFactory$1). Root cause NoClassDefFoundError (Could not initialize class org.testcontainers.shaded.com.github.dockerjava.okhttp.UnixSocketFactory$1)
09:49:43.247 [main] ERROR o.t.d.DockerClientProviderStrategy - As no valid configuration was found, execution cannot continue
```