### PR TITLE
integrate TestLens and add intentionally flaky tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Make docker-compose available on PATH
         run: sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
+      - name: Setup TestLens
+        uses: testlens-app/setup-testlens@v1
+
       - name: Build project
         id: build
         continue-on-error: true

--- a/src/test/java/de/rieckpil/courses/flaky/FlakyReviewApiIT.java
+++ b/src/test/java/de/rieckpil/courses/flaky/FlakyReviewApiIT.java
@@ -1,0 +1,84 @@
+package de.rieckpil.courses.flaky;
+
+import java.util.concurrent.TimeUnit;
+
+import com.nimbusds.jose.JOSEException;
+import de.rieckpil.courses.AbstractIntegrationTest;
+import de.rieckpil.courses.book.management.Book;
+import de.rieckpil.courses.book.management.BookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Intentionally flaky integration test to experiment with TestLens flaky test detection. The tight
+ * latency assertion depends on machine load and JVM warmup. Do not fix or stabilize it, the
+ * non-determinism is the point.
+ */
+class FlakyReviewApiIT extends AbstractIntegrationTest {
+
+  private static final String ISBN = "9780596004651";
+
+  @Autowired private WebTestClient webTestClient;
+
+  @Autowired private BookRepository bookRepository;
+
+  @BeforeEach
+  void setup() {
+    Book book = new Book();
+    book.setPublisher("Duke Inc.");
+    book.setIsbn(ISBN);
+    book.setPages(42L);
+    book.setTitle("Joyful testing with Spring Boot");
+    book.setDescription("Writing unit and integration tests for Spring Boot applications");
+    book.setAuthor("rieckpil");
+    book.setThumbnailUrl(
+        "https://rieckpil.de/wp-content/uploads/2020/08/tsbam_introduction_thumbnail-585x329.png.webp");
+    book.setGenre("Software Development");
+
+    this.bookRepository.save(book);
+  }
+
+  @Test
+  void shouldCreateReviewWithinTightLatencyBudget() throws JOSEException {
+
+    String reviewPayload =
+        """
+      {
+        "reviewTitle" : "Great book with lots of tips & tricks",
+        "reviewContent" : "I can really recommend reading this book. It includes up-to-date library versions and real-world examples",
+        "rating": 4
+      }
+      """;
+
+    String validJWT = getSignedJWT();
+    long latencyBudgetInMilliseconds = 300;
+
+    long startTime = System.nanoTime();
+
+    this.webTestClient
+        .post()
+        .uri("/api/books/{isbn}/reviews", ISBN)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + validJWT)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(reviewPayload)
+        .exchange()
+        .expectStatus()
+        .isCreated();
+
+    long elapsedInMilliseconds = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+    assertTrue(
+        elapsedInMilliseconds <= latencyBudgetInMilliseconds,
+        "Review creation took "
+            + elapsedInMilliseconds
+            + " ms but the latency budget is "
+            + latencyBudgetInMilliseconds
+            + " ms");
+  }
+}

--- a/src/test/java/de/rieckpil/courses/flaky/FlakySampledDataTest.java
+++ b/src/test/java/de/rieckpil/courses/flaky/FlakySampledDataTest.java
@@ -1,0 +1,29 @@
+package de.rieckpil.courses.flaky;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Intentionally flaky unit test to experiment with TestLens flaky test detection. The assertion
+ * depends on randomly sampled data. Do not fix or stabilize it, the non-determinism is the point.
+ */
+class FlakySampledDataTest {
+
+  @Test
+  void shouldContainHighRatingInRandomReviewSample() {
+    List<Integer> sampledRatings =
+        IntStream.range(0, 5)
+            .map(sampleIndex -> ThreadLocalRandom.current().nextInt(1, 6))
+            .boxed()
+            .toList();
+
+    assertTrue(
+        sampledRatings.contains(5),
+        "Expected at least one five-star rating in the sample but got " + sampledRatings);
+  }
+}

--- a/src/test/java/de/rieckpil/courses/flaky/FlakyShowcaseTest.java
+++ b/src/test/java/de/rieckpil/courses/flaky/FlakyShowcaseTest.java
@@ -1,0 +1,65 @@
+package de.rieckpil.courses.flaky;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Intentionally flaky unit tests to experiment with TestLens flaky test detection. Do not fix or
+ * stabilize them, the non-determinism is the point.
+ */
+class FlakyShowcaseTest {
+
+  private int visitCounter = 0;
+
+  @Test
+  void shouldCountAllVisitsFromConcurrentThreads() throws InterruptedException {
+    int threadCount = 4;
+    int incrementsPerThread = 100;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startSignal = new CountDownLatch(1);
+
+    for (int threadIndex = 0; threadIndex < threadCount; threadIndex++) {
+      executorService.submit(
+          () -> {
+            startSignal.await();
+            for (int incrementIndex = 0; incrementIndex < incrementsPerThread; incrementIndex++) {
+              // unsynchronized increment, concurrent updates can get lost
+              visitCounter++;
+            }
+            return null;
+          });
+    }
+
+    startSignal.countDown();
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
+
+    assertEquals(threadCount * incrementsPerThread, visitCounter);
+  }
+
+  @Test
+  void shouldFinishSlowComputationWithinDeadline() throws InterruptedException {
+    long deadlineInMilliseconds = 50;
+    long simulatedWorkInMilliseconds = ThreadLocalRandom.current().nextLong(20, 80);
+
+    long startTime = System.nanoTime();
+    Thread.sleep(simulatedWorkInMilliseconds);
+    long elapsedInMilliseconds = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+    assertTrue(
+        elapsedInMilliseconds <= deadlineInMilliseconds,
+        "Computation took "
+            + elapsedInMilliseconds
+            + " ms but the deadline is "
+            + deadlineInMilliseconds
+            + " ms");
+  }
+}


### PR DESCRIPTION
Add the setup-testlens GitHub Action to the Maven workflow and introduce three intentionally flaky tests (race condition, timing deadline, latency budget) to experiment with flaky test detection.