### PR TITLE
integrate TestLens for flaky test detection

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Make docker-compose available on PATH
         run: sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
+      - name: Setup TestLens
+        uses: testlens-app/setup-testlens@v1
+
       - name: Build project
         id: build
         continue-on-error: true


### PR DESCRIPTION
## What

Adds the [setup-testlens](https://github.com/testlens-app/setup-testlens) GitHub Action to the Maven build workflow, right before the `./mvnw verify` step.

## Why

The TestLens GitHub App is installed on this repository. The action patches the root POM at CI time with a profile that instruments the Surefire and Failsafe executions, so all unit and integration test results are reported to TestLens for flaky test detection. Results show up in the [Test Dashboard issue](https://github.com/rieckpil/testing-spring-boot-applications-masterclass/issues/500) and as PR comments when a PR build contains flaky or failing tests.

No test or POM changes in the repository itself - the workflow gets one new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)